### PR TITLE
feat: add support for view transitions

### DIFF
--- a/packages/starlight-image-zoom/components/ImageZoom.astro
+++ b/packages/starlight-image-zoom/components/ImageZoom.astro
@@ -178,11 +178,12 @@
         opened: 'starlight-image-zoom-opened',
         source: 'starlight-image-zoom-source',
       }
+      static #initialized = false
 
       constructor() {
         super()
 
-        window.addEventListener('DOMContentLoaded', () => {
+        const initialize = () => {
           // https://caniuse.com/requestidlecallback
           const onIdle = window.requestIdleCallback ?? ((cb) => setTimeout(cb, 1))
 
@@ -191,8 +192,20 @@
             if (zoomables.length === 0) return
 
             this.#setupZoom(zoomables)
+            document.addEventListener('click', this.#onClick)
+            window.addEventListener('resize', this.#onResize)
           })
-        })
+        }
+        window.addEventListener('DOMContentLoaded', initialize, { once: true })
+        document.addEventListener(
+          'astro:after-preparation',
+          () => {
+            document.removeEventListener('click', this.#onClick)
+            window.removeEventListener('resize', this.#onResize)
+          },
+          { once: true },
+        )
+        StarlightImageZoom.#initialized ||= document.addEventListener('astro:after-swap', initialize) === undefined
       }
 
       #setupZoom(zoomables: Element[]) {
@@ -207,9 +220,6 @@
             this.#open(img)
           })
         }
-
-        document.addEventListener('click', this.#onClick)
-        window.addEventListener('resize', this.#onResize)
       }
 
       #onClick = ({ target }: MouseEvent) => {
@@ -284,6 +294,8 @@
       }
 
       #close(disableAnimation = false) {
+        window.removeEventListener('wheel', this.#onWheel)
+
         if (!this.#currentZoom) return
 
         const { zoomedImage } = this.#currentZoom


### PR DESCRIPTION
**Describe the pull request**

Hi @HiDeoo, people have an issue using The Bags Starlight support.
starlight-image-zoom doesn't work any more as soon as they add view transitions.
I would be happy if you could integrate these changes to make ImageZoom compatible with Astro's view transitions. 


**Why**

Closes https://github.com/martrapp/astro-vtbot/issues/89

**How**

if ImageZoom should also work with view transitions, the initialization code that runs at `DOMContentLoaded` also needs to run on soft loads `after-swap` . 

As the web component runs the constructor whenever the component is inserted into the DOM, setting up the `astro:after-swap` listener needs a static property to keep track of initialization.

Without full page reloads, listeners on document and window need some cleanup, which I added `after-preparation`. To make that more symmetric, I also hoisted the addEventlistener calls for click and resize up into the idle callback.

Finally, there I added cleanup for the wheel handler in #close.  
 

