### PR TITLE
Remove warning when a `MarkdownContent` component override already exists

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -52,3 +52,22 @@ import { PackageManagers } from '@hideoo/starlight-plugins-docs-components'
 </Steps>
 
 The Starlight Image Zoom plugin behavior can be tweaked using various [configuration options](/configuration).
+
+## Component overrides
+
+The Starlight Image Zoom plugin uses a Starlight [component override](https://starlight.astro.build/guides/overriding-components/) for the [`MarkdownContent`](https://starlight.astro.build/reference/overrides/#markdowncontent) component to add zoom capabilities to images.
+
+If you have a custom `MarkdownContent` component override in your Starlight project, you will need to manually render the `ImageZoom` component from the Starlight Image Zoom plugin in your custom component:
+
+```diff lang="astro"
+---
+// src/components/overrides/MarkdownContent.astro
+import type { Props } from '@astrojs/starlight/props'
+import Default from '@astrojs/starlight/components/MarkdownContent.astro'
++import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro'
+---
+
++<ImageZoom />
+<p>Custom content in the MarkdownContent override</p>
+<Default {...Astro.props}><slot /></Default>
+```

--- a/packages/starlight-image-zoom/index.ts
+++ b/packages/starlight-image-zoom/index.ts
@@ -29,21 +29,14 @@ export default function starlightImageZoomPlugin(userConfig?: StarlightImageZoom
   return {
     name: 'starlight-image-zoom-plugin',
     hooks: {
-      setup({ addIntegration, config, logger, updateConfig }) {
+      setup({ addIntegration, config, updateConfig }) {
         const updatedConfig: Partial<StarlightUserConfig> = { components: { ...config.components } }
 
         if (!updatedConfig.components) {
           updatedConfig.components = {}
         }
 
-        if (config.components?.MarkdownContent) {
-          logger.warn(
-            'It looks like you already have a `MarkdownContent` component override in your Starlight configuration.',
-          )
-          logger.warn(
-            'To use `starlight-image-zoom`, either remove the override or manually render `starlight-image-zoom/components/ImageZoom.astro`.',
-          )
-        } else {
+        if (!config.components?.MarkdownContent) {
           updatedConfig.components.MarkdownContent = 'starlight-image-zoom/overrides/MarkdownContent.astro'
         }
 


### PR DESCRIPTION
Closes #18 

This PR removes the warning previously shown when a `MarkdownContent` component override already exists in the configuration and also adds a new section to the documentation explaining how to use this plugin with a custom `MarkdownContent` component.

See https://github.com/HiDeoo/starlight-image-zoom/issues/18#issuecomment-2299084545 for more details.