### PR TITLE
Center zoomed SVGs with non-default `preserveAspectRatio` values

### DIFF
--- a/.changeset/silent-loops-invite.md
+++ b/.changeset/silent-loops-invite.md
@@ -1,0 +1,5 @@
+---
+'starlight-image-zoom': patch
+---
+
+Fixes a zoomed SVG alignment issue for SVGs using non-default `preserveAspectRatio` values.

--- a/docs/src/assets/tests/preserve-aspect-ratio.svg
+++ b/docs/src/assets/tests/preserve-aspect-ratio.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="xMinYMin meet">
+  <circle cx="50" cy="50" r="50" fill="red" />
+</svg>

--- a/docs/src/content/docs/tests/zoom.mdx
+++ b/docs/src/content/docs/tests/zoom.mdx
@@ -25,3 +25,7 @@ import AstroLight from '../../../assets/tests/astro-light.svg'
 <Zoom label="Astro logo SVG component">
   <AstroLight alt="Astro logo" />
 </Zoom>
+
+An SVG image using `preserveAspectRatio="xMinYMin meet"`:
+
+![Preserve aspect ratio SVG](../../../assets/tests/preserve-aspect-ratio.svg)

--- a/packages/starlight-image-zoom/components/ImageZoom.astro
+++ b/packages/starlight-image-zoom/components/ImageZoom.astro
@@ -392,17 +392,17 @@ if (!config.showCaptions) dataAttributes['data-hide-caption'] = ''
       #cloneAndZoomImage(image: ZoomableElement) {
         const imageRect = image.getBoundingClientRect()
 
-        // Zoom SVG images at the figure's size, not the image's size.
+        // Preserve SVG aspect ratios while still allow them to scale up to the viewport.
         const isSVG = this.#isSVGElement(image) || this.#isSVGImage(image)
-        const naturalWidth = isSVG ? window.innerWidth : image.naturalWidth
-        const naturalHeight = isSVG ? window.innerHeight : image.naturalHeight
+        const naturalWidth = isSVG ? imageRect.width : image.naturalWidth
+        const naturalHeight = isSVG ? imageRect.height : image.naturalHeight
 
-        const maxWidth = Math.min(window.innerWidth, naturalWidth)
-        const maxHeight = Math.min(window.innerHeight, naturalHeight)
+        const maxWidth = isSVG ? window.innerWidth : Math.min(window.innerWidth, naturalWidth)
+        const maxHeight = isSVG ? window.innerHeight : Math.min(window.innerHeight, naturalHeight)
         const scale = Math.min(maxWidth / naturalWidth, maxHeight / naturalHeight)
 
-        const width = (isSVG ? window.innerWidth : image.naturalWidth) * scale
-        const height = (isSVG ? window.innerHeight : image.naturalHeight) * scale
+        const width = naturalWidth * scale
+        const height = naturalHeight * scale
         const top = (window.innerHeight - height) / 2
         const left = (window.innerWidth - width) / 2
 

--- a/packages/starlight-image-zoom/tests/zoom.test.ts
+++ b/packages/starlight-image-zoom/tests/zoom.test.ts
@@ -86,3 +86,21 @@ test('preserves image ID in the `data-zoom-id` attribute', async ({ testPage }) 
   expect(await zoomedImage.getAttribute('id')).toBe(null)
   expect(await zoomedImage.getAttribute('data-zoom-id')).toBe('astro-logo')
 })
+
+test('centers a zoomed SVG image while preserving its aspect ratio', async ({ testPage }) => {
+  await testPage.page.setViewportSize({ width: 1000, height: 600 })
+  await testPage.goto('zoom')
+
+  const image = testPage.page.getByAltText('Preserve aspect ratio SVG')
+
+  await testPage.zoomImage(image)
+
+  const zoomedBox = await testPage.getZoomedImage().boundingBox()
+
+  if (!zoomedBox) throw new Error('Could not get zoomed image bounding box')
+
+  expect(zoomedBox.width).toBe(600)
+  expect(zoomedBox.height).toBe(600)
+  expect(zoomedBox.x).toBe(200)
+  expect(zoomedBox.y).toBe(0)
+})


### PR DESCRIPTION
Closes #60 